### PR TITLE
Calendar template is not preselected when creating a new entry #18

### DIFF
--- a/application-mocca-calendar-ui/pom.xml
+++ b/application-mocca-calendar-ui/pom.xml
@@ -107,5 +107,14 @@
       <version>2.0.4</version>
       <type>xar</type>
     </dependency>
+    <!-- This application is needed to preselect the Calendar template at creation step according to
+      https://github.com/xwikisas/application-mocca-calendar/issues/18 only for xwiki versions until 9.5 -->
+    <dependency>
+      <groupId>com.xwiki.defaultPageTemplate</groupId>
+      <artifactId>application-defaultPageTemplate</artifactId>
+      <version>1.1</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/WebHome.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/WebHome.xml
@@ -82,6 +82,34 @@
   <object>
     <name>MoccaCalendar.WebHome</name>
     <number>0</number>
+    <className>XWiki.DefaultPageTemplateClass</className>
+    <guid>1767de4c-c8d6-40f8-b9aa-c53a372a1034</guid>
+    <class>
+      <name>XWiki.DefaultPageTemplateClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultPageTemplate>
+        <disabled>0</disabled>
+        <name>defaultPageTemplate</name>
+        <number>1</number>
+        <prettyName>defaultPageTemplate</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultPageTemplate>
+    </class>
+    <property>
+      <defaultPageTemplate>MoccaCalendar.MoccaCalendarTemplateProvider</defaultPageTemplate>
+    </property>
+  </object>
+  <object>
+    <name>MoccaCalendar.WebHome</name>
+    <number>0</number>
     <className>XWiki.UIExtensionClass</className>
     <guid>6d1cd96a-43d0-414c-bd80-b3e1ac15b8f0</guid>
     <class>


### PR DESCRIPTION
* added a new dependency to a small app that preselects Calendar template at creation step for older versions of xwiki then 9.5