### PR TITLE
Calendar is not loading in Firefox #38

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -138,7 +138,7 @@ or
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery', 'fullcalendar'], function(jQuery, fullCalendar) {
+      <code>define('moccaCalendar', ['jquery', 'fullcalendar'], function(jQuery, fullCalendar) {
 
 // Make sure the XWiki 'namespace' and the ModalPopup class exist.
 if (typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeof(XWiki.widgets.ModalPopup) == "undefined") {
@@ -1131,9 +1131,8 @@ $xwiki.ssx.use("MoccaCalendar.Macro")
 #end
 &lt;div id="calendar${calcounter}"&gt;&lt;/div&gt;
 &lt;script type="text/javascript"&gt;
-require(['jquery'], function(jQuery) {
- jQuery(window).load(function() {
-
+require(['jquery', 'moccaCalendar'], function(jQuery) {
+ jQuery(document).ready(function() {
   var defaultView = XWiki.MoccaCalendar.Helper.getCalendarView("$!escapetool.javascript($defaultView)");
 
   var defaultEventData = {


### PR DESCRIPTION
* changed back to ```$(document).ready``` as it was before [this change](https://github.com/xwikisas/application-mocca-calendar/commit/3c4e013cd9dc1fc3c456b51b5628d005452115ce#diff-2922c45d87c592fd9fb7ccef74b86f91L1137), since in that case  ```jQuery(window).load``` was used for avoiding ```XWiki.MoccaCalendar is undefined``` 
* in Firefox ```jQuery(window).load``` is not fired, so add the moccaCalendar module as a dependency instead, to be sure ```XWiki.MoccaCalendar``` was declared before