### PR TITLE
Issue #24: Future agenda events appear in the "today" view

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -631,7 +631,7 @@ if (typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || type
       return this.title;
     },
   
-    unrenderEvents: function() {
+    destroyEvents: function() {
       if (this.container) { this.container.empty(); }
     },
   


### PR DESCRIPTION
* unrenderEvents was replaced by destroyEvents in fullcalendar.io