### PR TITLE
Issue #51: Time format of the events when displayed on the calendar does not correspond to the dateformat event when displayed alone

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -1067,9 +1067,10 @@ $xwiki.ssx.use("MoccaCalendar.Macro")
 #if(!$date)
  #set($date = "")
 #end
+## If the date format is not set in MoccaCalendarEventClass, we are gone use the date format from the current wiki.
 #set($dateFormat = $!xwiki.getClass("MoccaCalendar.MoccaCalendarEventClass").get("startDate").getProperty('dateFormat').value)
 #if("$!dateFormat" == "")
-  #set($dateFormat = "dd.MM.yyyy HH:mm:ss")
+  #set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd.MM.yyyy HH:mm:ss'))
 #end
 
 ##
@@ -1201,7 +1202,7 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
     dayNamesShort: $services.localization.render('xwiki.calendar.dayNamesShort'),
     allDayText: "$escapetool.javascript($services.localization.render('xwiki.calendar.allDayText'))",
     axisFormat: "$escapetool.javascript($services.localization.render('xwiki.calendar.axisFormat'))",
-    timeFormat: "$!escapetool.javascript($services.localization.render('xwiki.calendar.timeFormat'))",
+    timeFormat: "$dateFormat.substring($dateFormat.indexOf('H'))",
     views: {
       month : {
         columnFormat: "$!services.localization.render('xwiki.calendar.columnFormat.month')",


### PR DESCRIPTION
* get dateformat from XWikiPreference when is not set in MoccaCalendarEventClass