### PR TITLE
Time format of the events when displayed on the calendar does not correspond to the dateformat event when displayed alone #51

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -1087,16 +1087,11 @@ $xwiki.ssx.use("MoccaCalendar.Macro")
 
 ## Set the time format from the date format, if the date format doesn't include information about the time, a default value will be set.
 #macro(setTimeFormat $dateFormat $timeFormat)
-  #if($dateFormat.indexOf('H') != -1)
-    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('H')))
-  #elseif($dateFormat.indexOf('K') != -1)
-    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('K')))
-  #elseif($dateFormat.indexOf('h') != -1)
-    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('h')))
-  #elseif($dateFormat.indexOf('k') != -1)
-    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('k')))
-  #else
+  #set($timeFormatStart = $stringtool.indexOfAny($dateFormat, 'HhKk'))
+  #if($timeFormatStart &lt; 0)
     #setVariable('$timeFormat', 'HH:mm')
+  #else
+    #setVariable('$timeFormat', $dateFormat.substring($timeFormatStart))
   #end
 #end
 #setTimeFormat($dateFormat, $timeFormat)
@@ -1229,7 +1224,7 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
     dayNamesShort: $services.localization.render('xwiki.calendar.dayNamesShort'),
     allDayText: "$escapetool.javascript($services.localization.render('xwiki.calendar.allDayText'))",
     axisFormat: "$escapetool.javascript($services.localization.render('xwiki.calendar.axisFormat'))",
-    timeFormat: "$timeFormat",
+    timeFormat: "$escapetool.javascript($timeFormat)",
     views: {
       month : {
         columnFormat: "$!services.localization.render('xwiki.calendar.columnFormat.month')",

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -1078,11 +1078,28 @@ $xwiki.ssx.use("MoccaCalendar.Macro")
 #if(!$date)
  #set($date = "")
 #end
+## If the date format is not set in MoccaCalendarEventClass, we are going to use the date format from the current wiki.
 #set($dateFormat = $!xwiki.getClass("MoccaCalendar.MoccaCalendarEventClass").get("startDate").getProperty('dateFormat').value)
 #if("$!dateFormat" == "")
-  #set($dateFormat = "dd.MM.yyyy HH:mm:ss")
+  ## If the date format set from the current xwiki is not set, a default value will be provided.
+  #set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd.MM.yyyy HH:mm'))
 #end
 
+## Set the time format from the date format, if the date format doesn't include information about the time, a default value will be set.
+#macro(setTimeFormat $dateFormat $timeFormat)
+  #if($dateFormat.indexOf('H') != -1)
+    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('H')))
+  #elseif($dateFormat.indexOf('K') != -1)
+    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('K')))
+  #elseif($dateFormat.indexOf('h') != -1)
+    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('h')))
+  #elseif($dateFormat.indexOf('k') != -1)
+    #setVariable('$timeFormat', $dateFormat.substring($dateFormat.indexOf('k')))
+  #else
+    #setVariable('$timeFormat', 'HH:mm')
+  #end
+#end
+#setTimeFormat($dateFormat, $timeFormat)
 ##
 ## some hardwired values that you can feel free to customize
 ##
@@ -1212,7 +1229,7 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
     dayNamesShort: $services.localization.render('xwiki.calendar.dayNamesShort'),
     allDayText: "$escapetool.javascript($services.localization.render('xwiki.calendar.allDayText'))",
     axisFormat: "$escapetool.javascript($services.localization.render('xwiki.calendar.axisFormat'))",
-    timeFormat: "$!escapetool.javascript($services.localization.render('xwiki.calendar.timeFormat'))",
+    timeFormat: "$timeFormat",
     views: {
       month : {
         columnFormat: "$!services.localization.render('xwiki.calendar.columnFormat.month')",


### PR DESCRIPTION
- get dateFormat from XWikiPreference when is not set in MoccaCalendarEventClass
- set timeFormat from the dateFormat, use a default value when dateFormat doesn't contain information about the time