### PR TITLE
Calendar displays times in 12h format although it uses 24h format in other places (including calendar macro parameters) #52

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Macro.xml
@@ -1234,12 +1234,14 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
       week : {
         columnFormat: "$!services.localization.render('xwiki.calendar.columnFormat.week')",
         titleFormat: "$!services.localization.render('xwiki.calendar.titleFormat.week')",
-        buttonText: "$!services.localization.render('xwiki.calendar.button.week')"
+        buttonText: "$!services.localization.render('xwiki.calendar.button.week')",
+        slotLabelFormat: "$escapetool.javascript($timeFormat)"
       },
       day : {
         columnFormat: "$!services.localization.render('xwiki.calendar.columnFormat.day')",
         titleFormat: "$!services.localization.render('xwiki.calendar.titleFormat.day')",
-        buttonText: "$!services.localization.render('xwiki.calendar.button.day')"
+        buttonText: "$!services.localization.render('xwiki.calendar.button.day')",
+        slotLabelFormat: "$escapetool.javascript($timeFormat)"
       },
       today: {
         buttonText: "$!services.localization.render('xwiki.calendar.button.today')"


### PR DESCRIPTION
- according to the documantation from the fullcalendar.io (https://fullcalendar.io/docs/v3/slotLabelFormat): we need to set the slotLabelFormat value
- set slotLabelFormat with the timeFormat value