### PR TITLE
#84: Add ability to display events from multiple wikis

### DIFF
--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/utils/DefaultEventAssembly.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/utils/DefaultEventAssembly.java
@@ -71,6 +71,10 @@ public class DefaultEventAssembly
     private QueryFilter hidden;
 
     @Inject
+    @Named("document")
+    private QueryFilter documentFilter;
+
+    @Inject
     @Named("viewable")
     private QueryFilter viewableFilter;
 
@@ -98,6 +102,7 @@ public class DefaultEventAssembly
             hqlQuery.bindValue(param.getKey(), param.getValue());
         }
         hqlQuery.addFilter(hidden);
+        hqlQuery.addFilter(documentFilter);
         hqlQuery.addFilter(viewableFilter);
 
         logger.debug("sending query [{}] and params [{}]", hqlQuery.getStatement(), query.queryParams);

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/utils/EventQuery.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/utils/EventQuery.java
@@ -65,6 +65,9 @@ public class EventQuery
     private final String startDateName;
     private final String endDateName;
 
+    /** Target wiki identifier where events will be searched for. */
+    private final String wikiId;
+
     private Logger logger;
 
     protected StringBuilder selectClause = new StringBuilder();
@@ -74,10 +77,17 @@ public class EventQuery
 
     public EventQuery(String className, String templatePageName, String startDateName, String endDateName)
     {
+        this(className, templatePageName, startDateName, endDateName, null);
+    }
+
+    public EventQuery(String className, String templatePageName, String startDateName, String endDateName,
+        String wikiId)
+    {
         this.className = className;
         this.templatePageName = templatePageName;
         this.startDateName = startDateName;
         this.endDateName = endDateName;
+        this.wikiId = wikiId;
         this.logger = LoggerFactory.getLogger(this.getClass());
         initQuery();
     }
@@ -85,6 +95,12 @@ public class EventQuery
     public EventQuery(String className, String templatePageName)
     {
         this(className, templatePageName, EventConstants.PROPERTY_STARTDATE_NAME, EventConstants.PROPERTY_ENDDATE_NAME);
+    }
+
+    public EventQuery(String className, String templatePageName, String wiki)
+    {
+        this(className, templatePageName, EventConstants.PROPERTY_STARTDATE_NAME, EventConstants.PROPERTY_ENDDATE_NAME,
+            wiki);
     }
 
     protected void initQuery()
@@ -242,5 +258,10 @@ public class EventQuery
     public String getEndDateName()
     {
         return endDateName;
+    }
+
+    public String getWikiId()
+    {
+        return wikiId;
     }
 }

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -112,6 +112,10 @@ public class MoccaCalendarScriptService implements ScriptService
     private QueryFilter hidden;
 
     @Inject
+    @Named("viewable")
+    private QueryFilter viewableFilter;
+
+    @Inject
     private Map<String, RecurrentEventGenerator> eventGenerators;
 
     @Inject
@@ -134,8 +138,8 @@ public class MoccaCalendarScriptService implements ScriptService
 
         try {
             Query query = queryManager.createQuery(CALENDAR_BASE_QUERY, Query.HQL).addFilter(hidden);
-            List<String> results = query.execute();
-            calenderRefs = eventAssembly.filterViewableEvents(results);
+            query.addFilter(viewableFilter);
+            calenderRefs = query.execute();
         } catch (QueryException qe) {
             logger.error("error while fetching calendars", qe);
         }

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -296,6 +296,7 @@ public class MoccaCalendarScriptService implements ScriptService
 
     /**
      * Gets the union of events on a set of wikis.
+     *
      * @param dateFrom the start range
      * @param dateTo the end range; can be null. in that case dates from a single day are returned
      * @param wikis list of wiki identifiers where events should be searched for

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -317,11 +317,13 @@ public class MoccaCalendarScriptService implements ScriptService
         throws QueryException
     {
         List<EventInstance> events = new ArrayList<>();
-        for (String wiki : wikis) {
-            events.addAll(queryEvents(dateFrom, dateTo, "wiki", wiki, null, sortAscending));
+        if (wikis != null) {
+            for (String wiki : wikis) {
+                events.addAll(queryEvents(dateFrom, dateTo, "wiki", wiki, null, sortAscending));
+            }
+            // Sort events globally
+            sortEvents(events, sortAscending);
         }
-        // Sort events globally
-        sortEvents(events, sortAscending);
         return events;
     }
 

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -112,6 +112,10 @@ public class MoccaCalendarScriptService implements ScriptService
     private QueryFilter hidden;
 
     @Inject
+    @Named("document")
+    private QueryFilter documentFilter;
+
+    @Inject
     @Named("viewable")
     private QueryFilter viewableFilter;
 
@@ -138,6 +142,7 @@ public class MoccaCalendarScriptService implements ScriptService
 
         try {
             Query query = queryManager.createQuery(CALENDAR_BASE_QUERY, Query.HQL).addFilter(hidden);
+            query.addFilter(documentFilter);
             query.addFilter(viewableFilter);
             calenderRefs = query.execute();
         } catch (QueryException qe) {

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -297,8 +297,8 @@ public class MoccaCalendarScriptService implements ScriptService
     /**
      * Gets the union of events on a set of wikis.
      *
-     * @param dateFrom the start range
-     * @param dateTo the end range; can be null. in that case dates from a single day are returned
+     * @param dateFrom the range start
+     * @param dateTo the range end; can be null. in that case dates from a single day are returned
      * @param wikis list of wiki identifiers where events should be searched for
      * @param sortAscending if true, sort events ascending by start date, else descending
      * @return a list of event instances matching the criteria; might be empty but never null

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
@@ -99,6 +99,7 @@
 ##
 #set($startQuery = $datetool.toDate('yyyy-M-d', $request.start))
 #set($endQuery = $datetool.toDate('yyyy-M-d', $request.end))
+#set ($wikis = "$!request.wikis")
 #set($orderAsc=true)
 #if("$!{request.outputView}"=="plainList" &amp;&amp; $datetool.difference($datetool.getDate(),$endQuery).getSeconds()&lt;0)
   #set($orderAsc=false)
@@ -109,7 +110,15 @@
   #set($filterDoc = $!{request.calendarDoc})
 #end
 ##
-#set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, "$!{request.filter}", $filterDoc, $orderAsc))
+#if ($wikis != '')
+  #set ($wikiIds = [])
+  #foreach ($wikiId in $wikis.split(','))
+    #set ($discard = $wikiIds.add($wikiId.trim()))
+  #end
+  #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, $wikiIds, $orderAsc))
+#else
+  #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, "$!{request.filter}", $filterDoc, $orderAsc))
+#end
 ##
 #set($jsondateformat = $xwiki.jodatime.getDateTimeFormatterForPattern("yyyy-MM-dd'T'HH:mm"))
 #set($calDocParam = "calendarDoc=$!{escapetool.url($request.calendarDoc)}")

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
@@ -110,7 +110,7 @@
 #end
 ##
 #set ($wikis = $request.getParameterValues('wikis'))
-#if ($wikis != $NULL)
+#if ($wikis != $NULL &amp;&amp; $wikis.size() &gt; 0)
   #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, $wikis, $orderAsc))
 #else
   #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, "$!{request.filter}", $filterDoc, $orderAsc))

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/JSONService.xml
@@ -42,7 +42,7 @@
 #end
 {{/velocity}}
 {{velocity filter="html" wiki="false"}}
-#if($xcontext.action == 'get')
+#if($xcontext.action == 'get' &amp;&amp; $services.csrf.isTokenValid($request.form_token))
 ##
 ## macro "renderAgendaView"
 ## render an event in "agenda" view
@@ -99,7 +99,6 @@
 ##
 #set($startQuery = $datetool.toDate('yyyy-M-d', $request.start))
 #set($endQuery = $datetool.toDate('yyyy-M-d', $request.end))
-#set ($wikis = "$!request.wikis")
 #set($orderAsc=true)
 #if("$!{request.outputView}"=="plainList" &amp;&amp; $datetool.difference($datetool.getDate(),$endQuery).getSeconds()&lt;0)
   #set($orderAsc=false)
@@ -110,12 +109,9 @@
   #set($filterDoc = $!{request.calendarDoc})
 #end
 ##
-#if ($wikis != '')
-  #set ($wikiIds = [])
-  #foreach ($wikiId in $wikis.split(','))
-    #set ($discard = $wikiIds.add($wikiId.trim()))
-  #end
-  #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, $wikiIds, $orderAsc))
+#set ($wikis = $request.getParameterValues('wikis'))
+#if ($wikis != $NULL)
+  #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, $wikis, $orderAsc))
 #else
   #set($events = $services.moccacalendar.queryEvents($startQuery, $endQuery, "$!{request.filter}", $filterDoc, $orderAsc))
 #end

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -1314,13 +1314,11 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #if(!$calcounter) #set($calcounter = 0) #else #set($calcounter = $calcounter + 1) #end
 #set($discard = $request.setAttribute('MoccaCalendar.Code.Macro:counter', $calcounter))
 #set ($wikis = "$!xcontext.macro.params.wikis")
+#set ($wikiList = [])
 #if ($wikis != '')
-  #set ($wikiList = [])
   #foreach ($wikiId in $wikis.split(','))
     #set ($discard = $wikiList.add($wikiId.trim()))
   #end
-#else
-  #set ($wikiList = [$xcontext.wiki])
 #end
 #set($filter = $xcontext.macro.params.filter)
 #if(!$filter)

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -1313,6 +1313,7 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #set($calcounter = $request.getAttribute('MoccaCalendar.Code.Macro:counter'))
 #if(!$calcounter) #set($calcounter = 0) #else #set($calcounter = $calcounter + 1) #end
 #set($discard = $request.setAttribute('MoccaCalendar.Code.Macro:counter', $calcounter))
+#set ($wikis = "$!xcontext.macro.params.wikis")
 #set($filter = $xcontext.macro.params.filter)
 #if(!$filter)
 #set($filter = 'page') ## possible values are wiki, space, page
@@ -1452,6 +1453,7 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
     xpage: 'plain',
     outputSyntax: 'plain',
     calendarDoc: "$!escapetool.javascript($calendarDoc)",
+    wikis: "$!escapetool.javascript($wikis)",
     filter: "$!escapetool.javascript($filter)",
     filterDoc: "$!escapetool.javascript($filterDoc)",
     classname: "MoccaCalendar.MoccaCalendarEventClass",
@@ -2380,6 +2382,84 @@ Mocca Calendar Macro
     </property>
     <property>
       <name>filterDoc</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>MoccaCalendar.Code.Macro</name>
+    <number>10</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>04a00699-7d87-4aad-a165-01213012b5d7</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>List of wiki identifiers whose events are shown, separated by a comma. If not specified, events of the current wiki are shown. If specified, the calendarDoc and filter parameters are not taken into account.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>wikis</name>
     </property>
     <property>
       <type/>

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -1314,6 +1314,14 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #if(!$calcounter) #set($calcounter = 0) #else #set($calcounter = $calcounter + 1) #end
 #set($discard = $request.setAttribute('MoccaCalendar.Code.Macro:counter', $calcounter))
 #set ($wikis = "$!xcontext.macro.params.wikis")
+#if ($wikis != '')
+  #set ($wikiList = [])
+  #foreach ($wikiId in $wikis.split(','))
+    #set ($discard = $wikiList.add($wikiId.trim()))
+  #end
+#else
+  #set ($wikiList = [$xcontext.wiki])
+#end
 #set($filter = $xcontext.macro.params.filter)
 #if(!$filter)
 #set($filter = 'page') ## possible values are wiki, space, page
@@ -1445,21 +1453,25 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #end
 &lt;div id="calendar${calcounter}"&gt;&lt;/div&gt;
 &lt;script type="text/javascript"&gt;
-require(['jquery', 'moccaCalendar'], function(jQuery) {
+require(['xwiki-meta', 'jquery', 'moccaCalendar'], function(xwikiMeta, jQuery) {
  jQuery(document).ready(function() {
   var defaultView = XWiki.MoccaCalendar.Helper.getCalendarView("$!escapetool.javascript($defaultView)");
+
+  var wikiList = $jsontool.serialize($wikiList);
+  wikiList = wikiList.map(item =&gt; encodeURIComponent(item));
 
   var defaultEventData = {
     xpage: 'plain',
     outputSyntax: 'plain',
     calendarDoc: "$!escapetool.javascript($calendarDoc)",
-    wikis: "$!escapetool.javascript($wikis)",
+    wikis: wikiList,
     filter: "$!escapetool.javascript($filter)",
     filterDoc: "$!escapetool.javascript($filterDoc)",
     classname: "MoccaCalendar.MoccaCalendarEventClass",
     startfield: "startDate",
     endfield: "endDate",
-    durationfield: ""
+    durationfield: "",
+    form_token: xwikiMeta.form_token
   };
 
   // page is now ready, initialize the calendar...
@@ -1476,6 +1488,7 @@ require(['jquery', 'moccaCalendar'], function(jQuery) {
       error: function() {
         calendarHelper.displayError();        
       },
+      traditional: true
     },
     eventClick: function(calEvent, jsEvent, view) {
       new XWiki.MoccaCalendar.MoccaCalendarPopup({editMode: false, event: calEvent}, calendarHelper);


### PR DESCRIPTION
- Add parameter "wikis" to the MoccaCalendar.Code.Macro
- Add field "wikiId" in EventQuery
- Take into account this new field in DefaultAssembly when executing
  query and filtering viewable events
- In MoccaCalendarScriptService, add method for querying events on a
  list of wikis
- Update JSONService to take into account the list of wikis, if any

@ClemensRobbenhaar @mflorea that'd be great to have your take on this if possible!