### PR TITLE
#96: Meeting events are not included in multiwiki calendars

### DIFF
--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/meetings/MeetingEventSource.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/internal/meetings/MeetingEventSource.java
@@ -136,13 +136,21 @@ public class MeetingEventSource implements EventSource
                 logger.debug("no source space for events");
             }
 
-            EventQuery evQ = new EventQuery(MEETING_ENTRY_CLASS_NAME, MEETING_TEMPLATE_PAGE);
+            EventQuery evQ = null;
+            if (sourceDoc != null) {
+                evQ = new EventQuery(MEETING_ENTRY_CLASS_NAME, MEETING_TEMPLATE_PAGE, sourceDoc.getWikiReference()
+                    .getName());
+            } else {
+                evQ = new EventQuery(MEETING_ENTRY_CLASS_NAME, MEETING_TEMPLATE_PAGE);
+            }
 
             // filter by date range
             evQ.addDateLimits(dateFrom, dateTo);
 
-            // filter by event location
-            evQ.addLocationFilter(filter, sourceDoc);
+            // filter by event location in case filter is not "wiki"
+            if (!"wiki".equals(filter)) {
+                evQ.addLocationFilter(filter, sourceDoc);
+            }
 
             // finally the ordering
             evQ.setAscending(sortAscending);
@@ -168,7 +176,7 @@ public class MeetingEventSource implements EventSource
         try {
             XWikiContext context = xcontextProvider.get();
             XWikiDocument eventDoc = context.getWiki().getDocument(meetingDocRef, context);
-            BaseObject eventData = eventDoc.getXObject(stringDocRefResolver.resolve(evQ.getClassName()));
+            BaseObject eventData = eventDoc.getXObject(stringDocRefResolver.resolve(evQ.getClassName(), meetingDocRef));
             if (eventData == null) {
                 logger.error("data inconsistency: query returned [{}] which contains no object for [{}]",
                     meetingDocRef, evQ.getClassName());

--- a/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
+++ b/application-mocca-calendar-api/src/main/java/org/xwiki/contrib/moccacalendar/script/MoccaCalendarScriptService.java
@@ -63,6 +63,9 @@ import org.xwiki.query.QueryFilter;
 import org.xwiki.query.QueryManager;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.script.service.ScriptService;
+import org.xwiki.wiki.descriptor.WikiDescriptor;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+import org.xwiki.wiki.manager.WikiManagerException;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -128,6 +131,9 @@ public class MoccaCalendarScriptService implements ScriptService
     @Inject
     private DefaultEventAssembly eventAssembly;
 
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+    
     @Inject
     private Logger logger;
 
@@ -287,6 +293,16 @@ public class MoccaCalendarScriptService implements ScriptService
                 continue;
             }
             logger.debug("add events from [{}] source", meetings.getKey());
+            // In case the filter is "wiki" and "parentRef" is null, we create one pointing at the wiki home
+            // in order to be able to retrieve the target wiki reference when retrieving the events in MeetingEventSource
+            if ("wiki".equals(filter) && parentRef == null) {
+                try {
+                    WikiDescriptor wikiDescriptor = wikiDescriptorManager.getById(wiki);
+                    parentRef = wikiDescriptor.getMainPageReference();
+                } catch (WikiManagerException e) {
+                    logger.error("Could not retrieve wiki descriptor for [{}]", wiki, e);
+                }
+            }
             List<EventInstance> meetingEvents = meetings.getValue().getEvents(dateFrom, dateTo, filter,
                 parentRef, sortAscending);
             if (meetingEvents != null) {


### PR DESCRIPTION
- When the filter is set to "wiki", pass to the MeetingEventSource a reference to the target wiki home page