### PR TITLE
 Update imported events from gCals and iCals to not display XWiki syntax#119

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
@@ -275,25 +275,24 @@ $doc.display($field)
       &lt;/dt&gt;
       &lt;dd&gt;$request.title&lt;/dd&gt;
       &lt;dt&gt;&lt;label
-              for="startDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_startDate'))&lt;/label&gt;
+            for="startDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_startDate'))&lt;/label&gt;
       &lt;/dt&gt;
       &lt;dd&gt;$request.start&lt;/dd&gt;
       &lt;dt&gt;&lt;label
-              for="endDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_endDate'))&lt;/label&gt;
+            for="endDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_endDate'))&lt;/label&gt;
       &lt;/dt&gt;
       &lt;dd&gt;$request.end&lt;/dd&gt;
       &lt;dt&gt;&lt;label
-              for="allDay"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_allDay'))&lt;/label&gt;
+            for="allDay"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_allDay'))&lt;/label&gt;
       &lt;/dt&gt;
       &lt;dd&gt;$request.allDay&lt;/dd&gt;
       &lt;dt&gt;&lt;label for="description"&gt;$escapetool.xml($services.localization.render('description'))&lt;/label&gt;&lt;/dt&gt;
       &lt;dd&gt;
-          $request.description
+        $request.description
       &lt;/dd&gt;
     &lt;/dl&gt;
     #end
   {{/html}}
-
   #end
   #end ## if isEdit else part
 

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
@@ -263,21 +263,34 @@ $doc.display($field)
     : $doc.display('recurrent')
     #end
   #else
+  {{html xwiki='false'}}
     #if($!{request.readOnly} != "true")
       $escapetool.xml($services.localization.render('MoccaCalendar.calendar.noevent'))
     #else
-    ; &lt;label&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_title'))&lt;/label&gt;
-    : $request.title
-    ; &lt;label for="startDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_startDate'))&lt;/label&gt;
-    : $request.start
-    ; &lt;label for="endDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_endDate'))&lt;/label&gt;
-    : $request.end
-    ; &lt;label for="allDay"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_allDay'))&lt;/label&gt;
-    ## XXX allDay cannot be modified yet, but we will need a localized string representation in the eventInstance for this if we make if modifiable!
-    : $request.allDay
-    ; &lt;label for="description"&gt;$escapetool.xml($services.localization.render('description'))&lt;/label&gt;
-    : $request.description
+    &lt;dl&gt;
+      &lt;dt&gt;&lt;label&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_title'))&lt;/label&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;$request.title&lt;/dd&gt;
+      &lt;dt&gt;&lt;label
+              for="startDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_startDate'))&lt;/label&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;$request.start&lt;/dd&gt;
+      &lt;dt&gt;&lt;label
+              for="endDate"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_endDate'))&lt;/label&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;$request.end&lt;/dd&gt;
+      &lt;dt&gt;&lt;label
+              for="allDay"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.MoccaCalendarEventClass_allDay'))&lt;/label&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;$request.allDay&lt;/dd&gt;
+      &lt;dt&gt;&lt;label for="description"&gt;$escapetool.xml($services.localization.render('description'))&lt;/label&gt;&lt;/dt&gt;
+      &lt;dd&gt;
+          $request.description
+      &lt;/dd&gt;
+    &lt;/dl&gt;
     #end
+  {{/html}}
+
   #end
   #end ## if isEdit else part
 

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
@@ -263,6 +263,9 @@ $doc.display($field)
     : $doc.display('recurrent')
     #end
   #else
+  ## This branch is only reached by events from iCals and gCals. The "xwiki false" setting is necessary because we
+  ## don't have control over the data from other providers. If the wiki syntax is set to true, the data might be
+  ## interpreted in a strange way and break the display.
   {{html xwiki='false'}}
     #if($!{request.readOnly} != "true")
       $escapetool.xml($services.localization.render('MoccaCalendar.calendar.noevent'))


### PR DESCRIPTION
 * Updated the modal to not use xwiki syntax when displaying the read only events.