### PR TITLE
Calendar import does not work if the iCal file has empty title events #127

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/ImportJobResource.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/ImportJobResource.xml
@@ -42,6 +42,7 @@
   #set ($importJobStatusJSON = {
     'id': $importJobStatus.request.id,
     'state': $importJobStatus.state,
+    'error': $importJobStatus.error,
     'progress': {
       'offset': $importJobStatus.progress.offset
     }

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -986,12 +986,15 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
           }
         };
       }
-    }).run(targetURL, data)).then(() =&gt; {
-      document.dispatchEvent(new Event('calendarImportCompleted'));
-      notification.replace(new XWiki.widgets.Notification(l10n.get('done'),'done'));
+    }).run(targetURL, data)).then((response) =&gt; {
+      if (response.error !== null) {
+        throw new Error(response.error.message);
+      } else {
+        document.dispatchEvent(new Event('calendarImportCompleted'));
+        notification.replace(new XWiki.widgets.Notification(l10n.get('done'),'done'));
+      }
     }).catch((reason) =&gt; {
-      notification.replace(new
-        XWiki.widgets.Notification(l10n.get('error'),'error'));
+      notification.replace(new XWiki.widgets.Notification(l10n.get('error'),'error'));
       return Promise.reject(reason);
     }).finally(() =&gt; {
       $('#import-calendar-file-button').prop('disabled', false);


### PR DESCRIPTION
Added a check for empty titles and a new error throw in case the import job fails.