### PR TITLE
Clicking recurrent events from subscribed calendars doesn't work #131

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -1807,7 +1807,7 @@ require(['xwiki-meta', 'jquery', 'moment','purify', 'gcal', 'moccaCalendar'], fu
         const params = {
           title: purify.sanitize(calEvent.title),
           start: calEvent.start.format(dateFormat),
-          end: calEvent.end.format(dateFormat),
+          end: calEvent.end ? calEvent.end.format(dateFormat) : null,
           allDay: calEvent.allDay ? "$escapetool.xml($services.localization.render('moccacalendar.subscribedevent.allday.yes'))" :
                                     "$escapetool.xml($services.localization.render('moccacalendar.subscribedevent.allday.no'))",
           description: purify.sanitize(calEvent.description),


### PR DESCRIPTION
* Fixed error when event end is null