### PR TITLE
iCal import does not work #138

### DIFF
--- a/application-mocca-calendar-api/pom.xml
+++ b/application-mocca-calendar-api/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>macro-fullcalendar-api</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/application-mocca-calendar-test/application-mocca-calendar-test-docker/pom.xml
+++ b/application-mocca-calendar-test/application-mocca-calendar-test-docker/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.mocca-calendar</groupId>
     <artifactId>application-mocca-calendar-test</artifactId>
-    <version>2.14.3-SNAPSHOT</version>
+    <version>2.15.1-SNAPSHOT</version>
   </parent>
   <artifactId>application-mocca-calendar-test-docker</artifactId>
   <name>Calendar Application - Test - Functional Docker Tests</name>

--- a/application-mocca-calendar-ui/pom.xml
+++ b/application-mocca-calendar-ui/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>macro-fullcalendar-ui</artifactId>
-      <version>2.4.0</version>
+      <version>2.4.2</version>
       <type>xar</type>
     </dependency>
     <!-- Replaces transitive dependency on com.sun.mail:javax.mail from ical4j (macro-fullcalendar-ui) -->


### PR DESCRIPTION
Updated the fullcalendar dependency version to include the latest fixes: https://github.com/xwiki-contrib/macro-fullcalendar/commit/88fc169c30bfe2bfc744ed3339f0dee8fd090a24.