### PR TITLE
Default parameter of the macro does not display events that are created #144

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -1625,22 +1625,29 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
           #set ($escapedCalendarSpace = $escapetool.xml($doc.getSpace()))
           #set ($escapedCalendarName = $escapetool.xml($doc.getDocumentReference().getName()))
           #set ($actionURL = "$request.getContextPath()/rest/moccacalendar/import")
+          #set ($xwikiCalendarDoc = $xwiki.getDocument($calendarDoc))
+          #set ($calendarObject = $xwikiCalendarDoc.getObject('MoccaCalendar.MoccaCalendarClass'))
           &lt;form class="xform" action="$actionURL" method="post"&gt;
             &lt;div class="import-form"&gt;
-              &lt;label for="import-calendar-parent"&gt;
-                $escapetool.xml($services.localization.render('MoccaCalendar.calendar'))&lt;/label&gt;
-              &lt;select id="import-calendar-parent" name="parentCalendar"&gt;
-                #foreach ($item in $services.moccacalendar.getAllCalendars()) ## TODO: add filter here, see MOCCACAL-76
-                  #set ($itemdoc = $xwiki.getDocument($item))
-                  #if ($!{itemdoc} &amp;&amp; ${itemdoc.hasAccessLevel("edit")})
-                    #set ($selected="")
-                    #if ($itemdoc.getId() == $doc.getId())
-                      #set ($selected=" selected='selected'")
+              #if ($calendarObject || $xwikiCalendarDoc.getFullName() == 'MoccaCalendar.Events')
+                &lt;label for="import-calendar-parent"&gt;
+                  $escapetool.xml($services.localization.render('MoccaCalendar.calendar'))&lt;/label&gt;
+                &lt;select id="import-calendar-parent" name="parentCalendar"&gt;
+                  #foreach ($item in $services.moccacalendar.getAllCalendars()) ## TODO: add filter here, see MOCCACAL-76
+                    #set ($itemdoc = $xwiki.getDocument($item))
+                    #if ($!{itemdoc} &amp;&amp; ${itemdoc.hasAccessLevel("edit")})
+                      #set ($selected="")
+                      #if ($itemdoc.getId() == $doc.getId())
+                        #set ($selected=" selected='selected'")
+                      #end
+                      &lt;option value="$escapetool.html($itemdoc.getFullName())"$selected&gt;
+                        $itemdoc.getDisplayTitle()&lt;/option&gt;
                     #end
-                    &lt;option value="$escapetool.html($itemdoc.getFullName())"$selected&gt;
-                      $itemdoc.getDisplayTitle()&lt;/option&gt;
                   #end
-                #end
+                &lt;/select&gt;
+              #end
+              &lt;select id="import-calendar-parent" name="parentCalendar" hidden&gt;
+                &lt;option value="$calendarDoc" selected&gt;$calendarDoc.getDisplayTitle()&lt;/option&gt;
               &lt;/select&gt;
               &lt;label for="import-ical-file-input"&gt;$escapetool.xml($services.localization.render(
                 'MoccaCalendar.import.modal.file.label'))&lt;/label&gt;

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarEventSheet.xml
@@ -160,7 +160,7 @@ $doc.display($field)
   &lt;div id="allEventsFields"&gt;
 
   #end
-
+  #if($calendar || $calendarDoc.getFullName() == 'MoccaCalendar.Events')
     ; &lt;label for="calendar"&gt;$escapetool.xml($services.localization.render('MoccaCalendar.calendar'))&lt;/label&gt;
     : &lt;select id="calendarParent" name="$parentParamName"&gt;
     #foreach($item in $services.moccacalendar.getAllCalendars()) ## TODO: add filter here, see MOCCACAL-76
@@ -174,7 +174,10 @@ $doc.display($field)
       #end
     #end
     &lt;/select&gt;
-
+  #end
+   &lt;select id="calendarParent" name="$parentParamName" hidden&gt;
+     &lt;option value="$escapetool.html($calendarDoc.getFullName())" selected&gt;$calendarDoc.getDisplayTitle()&lt;/option&gt;
+   &lt;/select&gt;
     ; &lt;label for="${editPrefix}_title"&gt;$escapetool.xml($doc.displayPrettyName('title', false, false))
         &lt;span class="xRequired"&gt;&lt;/span&gt;&lt;/label&gt;
     : &lt;input type="text" name="title" value="${escapetool.xml($doc.getDisplayTitle())}" /&gt;#showvalidationmessage("val_title_already_exists")


### PR DESCRIPTION
Added conditional rendering of calendar select for those calendars that are used as a macro and do not have the `MoccaCalendarClass` object. 
This was done as currently, if a calendar macro is used on a page without the `MoccaCalendarClass` object, there is no way to add an event because a calendar with the above mentioned object will be automatically selected.