### PR TITLE
Add the option to add the calendar class object to a used calendar macro. #146

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -948,6 +948,32 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
     startUploading(form);
   });
 
+  $(document).on('click', '#add-calendar-object', function(event) {
+    event.preventDefault();
+    const addObjectButton = $('#add-calendar-object');
+    const target = addObjectButton.data('target');
+    // To be adapted to the standard XWiki rest endpoint for object creation after
+    // XWIKI-20704: NullPointerException (NPE) when accessing objects with ComputedField properties from REST is fixed.
+    var documentReference = XWiki.Model.resolve('MoccaCalendar.Code.MoccaCalendarObjectCreator',
+      XWiki.EntityType.DOCUMENT);
+    var targetUrl = new XWiki.Document(documentReference).getURL();
+    var params = {
+      'documentRef': target
+    };
+    $.ajax({
+      url: targetUrl,
+      type: 'POST',
+      data: params,
+      success: function (response) {
+        window.location.reload();
+      },
+      error: function (xhr, status, error) {
+        console.error("Failed to add the MoccaCalendarClass object", error);
+        alert("An error occurred while trying to add the class object.");
+      }
+    });
+  });
+
   // Start uploading this file by creating a new XHR object with the file data.
   var startUploading = function (form) {
     var formData = new FormData(form);
@@ -1666,6 +1692,11 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
     &lt;/div&gt;
   &lt;/div&gt;
 #end
+#macro (addCalendarObject $docRef)
+  #info($escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.description')))
+  &lt;input type="button" class="btn btn-primary" id="add-calendar-object" data-target="$docRef"
+    value="$escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.button'))"&gt;
+#end
 {{/velocity}}
 
 {{velocity}}
@@ -1731,6 +1762,11 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #if($xcontext.action=='view'){{html clean="false" wiki="false"}}
 #if($canCreateEvents)
 ## create event link
+#set ($xwikiCalendarDoc = $xwiki.getDocument($calendarDoc))
+#set ($calendarObject = $xwikiCalendarDoc.getObject('MoccaCalendar.MoccaCalendarClass'))
+#if ($filter == 'page' &amp;&amp; !$calendarObject)
+  #addCalendarObject($calendarDoc)
+#end
 &lt;div class="calendar-buttons"&gt;
 &lt;span class="buttonwrapper"&gt;
 &lt;button data-toggle="modal" data-target="#import-calendar-file"

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -889,20 +889,21 @@ if (typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || type
 
 });
 
-define('mocca-calendar-import-notification', {
-  prefix: 'MoccaCalendar.import.notification.',
+define('mocca-calendar-notification', {
+  prefix: 'MoccaCalendar.notification.',
   keys: [
-    'inprogress',
-    'done',
-    'error',
-    'filetoolarge'
+    'import.inprogress',
+    'import.done',
+    'import.error',
+    'import.filetoolarge',
+    'addObject.error'
   ]
 });
 
 /**
  * Delete event and calendar import actions.
  */
-require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-import-notification'],
+require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-notification'],
   function($, xwikiMeta, JobRunner, l10n) {
   /**
   * Events triggered before deleteEvents modal is shown: save the button that triggers
@@ -948,7 +949,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
     startUploading(form);
   });
 
-  $(document).on('click', '#add-calendar-object', function(event) {
+  $(document).on('click', '.box.infomessage &gt; p &gt; span &gt; a', function(event) {
     event.preventDefault();
     const addObjectButton = $('#add-calendar-object');
     const target = addObjectButton.data('target');
@@ -968,8 +969,8 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
         window.location.reload();
       },
       error: function (xhr, status, error) {
-        console.error("Failed to add the MoccaCalendarClass object", error);
-        alert("An error occurred while trying to add the class object.");
+        console.error('Failed to add the MoccaCalendarClass object', error);
+        var notification = new XWiki.widgets.Notification(l10n.get('addObject.error'), 'error');
       }
     });
   });
@@ -989,7 +990,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
       request.send(formData);
       checkImportJob(select.value);
     } else {
-      var notification = new XWiki.widgets.Notification(l10n.get('filetoolarge'), 'error');
+      var notification = new XWiki.widgets.Notification(l10n.get('import.filetoolarge'), 'error');
     }
   }
 
@@ -1006,7 +1007,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
       {name: 'data', value: 'jobStatus'},
       {name: 'form_token', value: xwikiMeta.form_token}
     );
-    var notification = new XWiki.widgets.Notification(l10n.get('inprogress'), 'inprogress');
+    var notification = new XWiki.widgets.Notification(l10n.get('import.inprogress'), 'inprogress');
     $('#import-calendar-file-button').prop('disabled', true);
     return Promise.resolve(new JobRunner({
       createStatusRequest: function(jobId) {
@@ -1025,10 +1026,10 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!mocca-calendar-
         throw new Error(response.error.message);
       } else {
         document.dispatchEvent(new Event('calendarImportCompleted'));
-        notification.replace(new XWiki.widgets.Notification(l10n.get('done'),'done'));
+        notification.replace(new XWiki.widgets.Notification(l10n.get('import.done'),'done'));
       }
     }).catch((reason) =&gt; {
-      notification.replace(new XWiki.widgets.Notification(l10n.get('error'),'error'));
+      notification.replace(new XWiki.widgets.Notification(l10n.get('import.error'),'error'));
       return Promise.reject(reason);
     }).finally(() =&gt; {
       $('#import-calendar-file-button').prop('disabled', false);
@@ -1693,9 +1694,14 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
   &lt;/div&gt;
 #end
 #macro (addCalendarObject $docRef)
-  #info($escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.description')))
-  &lt;input type="button" class="btn btn-primary" id="add-calendar-object" data-target="$docRef"
-    value="$escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.button'))"&gt;
+  {{html clean=false wiki=true}}
+    &lt;input type="hidden" id="add-calendar-object" data-target="$docRef"&gt;
+
+    {{info}}
+      $escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.description'))
+      [[**$escapetool.xml($services.localization.render('rendering.macro.moccacalendar.addObject.button'))**&gt;&gt;$docRef]]
+    {{/info}}
+  {{/html}}
 #end
 {{/velocity}}
 
@@ -1759,14 +1765,15 @@ $xwiki.ssx.use("MoccaCalendar.Code.Macro")
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
   {{missingLicenseMessage extensionName="moccacalendar.extension.name"/}}
 #else
-#if($xcontext.action=='view'){{html clean="false" wiki="false"}}
-#if($canCreateEvents)
-## create event link
+#if($xcontext.action=='view')
 #set ($xwikiCalendarDoc = $xwiki.getDocument($calendarDoc))
 #set ($calendarObject = $xwikiCalendarDoc.getObject('MoccaCalendar.MoccaCalendarClass'))
 #if ($filter == 'page' &amp;&amp; !$calendarObject)
   #addCalendarObject($calendarDoc)
 #end
+{{html clean="false" wiki="false"}}
+#if($canCreateEvents)
+## create event link
 &lt;div class="calendar-buttons"&gt;
 &lt;span class="buttonwrapper"&gt;
 &lt;button data-toggle="modal" data-target="#import-calendar-file"

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/MoccaCalendarObjectCreator.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/MoccaCalendarObjectCreator.xml
@@ -1,0 +1,49 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="MoccaCalendar.Code.MoccaCalendarObjectCreator" locale="">
+  <web>MoccaCalendar.Code</web>
+  <name>MoccaCalendarObjectCreator</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>MoccaCalendarObjectCreator</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+  ## To be replaced with the rest endpoint call after
+  ## XWIKI-20704: NullPointerException (NPE) when accessing objects with ComputedField properties from REST is fixed.
+  #if ($request.method == 'POST')
+    #set ($targetDocument = $xwiki.getDocument($request.documentRef))
+    #set ($object = $targetDocument.getObject('MoccaCalendar.MoccaCalendarClass', true))
+    #set ($discard = $targetDocument.save())
+  #end
+{{/velocity}}
+</content>
+</xwikidoc>

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTranslations.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTranslations.xml
@@ -225,6 +225,8 @@ moccacalendar.sheets.generic.noevent=This page cannot be displayed in the calend
 moccacalendar.sources.config.label=Configure events from source \u00AB{0}\u00BB
 
 ## Calendar macro
+rendering.macro.moccacalendar.addObject.description=This action will transform the curent calendar macro in a dedicated Calendar page. This will allow further customizations of color schemes and you will find it in the Calendar overview. Note that the text inserted before the macro will be added in the calendar description. The action is irreversible!
+rendering.macro.moccacalendar.addObject.button=Add calendar class
 rendering.macro.moccacalendar.name=Mocca Calendar
 rendering.macro.moccacalendar.description=Displays a Calendar
 rendering.macro.moccacalendar.parameter.filter.name=Show events from ...

--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTranslations.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTranslations.xml
@@ -68,13 +68,16 @@ MoccaCalendar.generic.errormessage=Internal Server Error
 MoccaCalendar.import.modal.title=Import calendar
 MoccaCalendar.import.modal.file.label=.ics file to be imported
 MoccaCalendar.import.modal.button.start=Begin import
-MoccaCalendar.import.notification.inprogress=Calendar file import in progress...
-MoccaCalendar.import.notification.done=Calendar successfully imported!
-MoccaCalendar.import.notification.error=There was an error while importing the calendar data. Please try again or consult the logs!
-MoccaCalendar.import.notification.filetoolarge=The file size is too large
 MoccaCalendar.import.generated.description.attendee=Attendee: {0}
 MoccaCalendar.import.generated.description.location=Location: {0}
 MoccaCalendar.import.generated.description.organizer=Organizer: {0}
+
+# Notifications
+MoccaCalendar.notification.import.inprogress=Calendar file import in progress...
+MoccaCalendar.notification.import.done=Calendar successfully imported!
+MoccaCalendar.notification.import.error=There was an error while importing the calendar data. Please try again or consult the logs!
+MoccaCalendar.notification.import.filetoolarge=The file size is too large
+MoccaCalendar.notification.addObject.error=An error occurred while trying to add the class object.
 
 # Class fields
 MoccaCalendar.MoccaCalendarClass_title=Title
@@ -225,7 +228,7 @@ moccacalendar.sheets.generic.noevent=This page cannot be displayed in the calend
 moccacalendar.sources.config.label=Configure events from source \u00AB{0}\u00BB
 
 ## Calendar macro
-rendering.macro.moccacalendar.addObject.description=This action will transform the curent calendar macro in a dedicated Calendar page. This will allow further customizations of color schemes and you will find it in the Calendar overview. Note that the text inserted before the macro will be added in the calendar description. The action is irreversible!
+rendering.macro.moccacalendar.addObject.description=This action will transform the current calendar macro in a dedicated Calendar page. This will allow further customizations of color schemes and you will find it in the Calendar overview. Note that any other content on this page will be added in the calendar description. The action is irreversible!
 rendering.macro.moccacalendar.addObject.button=Add calendar class
 rendering.macro.moccacalendar.name=Mocca Calendar
 rendering.macro.moccacalendar.description=Displays a Calendar


### PR DESCRIPTION
Added a button in the interface to add the MoccaCalendarClass and created a new page that handles the class object addition.

![image](https://github.com/user-attachments/assets/cd6e68dd-2daf-4ed4-ab93-750cfc95a45c)
