### PR TITLE
Impossible to add a calendar in a location that is different from the root MoccaCalendar #158

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTemplateProvider.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/MoccaCalendarTemplateProvider.xml
@@ -256,15 +256,13 @@
       <name>templateProvider.calendar.name</name>
     </property>
     <property>
-      <spaces>
-        <value>MoccaCalendar</value>
-      </spaces>
+      <spaces/>
     </property>
     <property>
       <template>MoccaCalendar.MoccaCalendarTemplate</template>
     </property>
     <property>
-      <terminal/>
+      <terminal>0</terminal>
     </property>
     <property>
       <visibilityRestrictions/>


### PR DESCRIPTION
Removed space restriction for Mocca calendar template.