### PR TITLE
Can't create allDay events in new versions of XWiki #188

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/Code/Macro.xml
@@ -441,11 +441,11 @@ if (typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || type
       }
       this.content.title.value = purify.sanitize(this.content.title.value)
       this.content.writeAttribute('action', saveUrl + '&amp;xpage=plain&amp;ajax=true');
-      this.content.querySelectorAll('input.datetime').forEach(a =&gt; {
+      this.content.querySelectorAll('input.datetime').forEach(dateInput =&gt; {
         // Convert the date fields from the displayed format to the one accepted by the backend.
-        const parsedDate = moment(a.value, moment().toMomentFormatString(a.getAttribute('data-format')));
+        const dateObj = moment(dateInput.value, moment().toMomentFormatString(dateInput.getAttribute('data-format')));
         const calendarEventObjectDateFormat = moment().toMomentFormatString(this.helper.dateFormat);
-        a.value = parsedDate.isValid() ? parsedDate.format(calendarEventObjectDateFormat) : "";
+        dateInput.value = dateObj.isValid() ? dateObj.format(calendarEventObjectDateFormat) : "";
       });
       this.content.request({
         onSuccess: function() {


### PR DESCRIPTION
Added an extra step before sending the date to the backend, to reformat it in the expected date format.