### PR TITLE
Missing table header and incorrect heading level #136

### DIFF
--- a/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/WebHome.xml
+++ b/application-mocca-calendar-ui/src/main/resources/MoccaCalendar/WebHome.xml
@@ -71,7 +71,7 @@
 #set ($columns = ['doc.title', 'doc.creator', '_actions'])
 #livetable('moccacalendar' $columns $columnsProperties $options)
 ----
-====== $escapetool.xml($services.localization.render('MoccaCalendar.calendar.viewSubscribed')) ======
+=== $escapetool.xml($services.localization.render('MoccaCalendar.calendar.viewSubscribed')) ===
 ## Subscribed calendars livedata
 {{liveData
   id="subscribedCalendars"


### PR DESCRIPTION
*changed header level from h6 to h3

# Issue URL

https://github.com/xwikisas/application-mocca-calendar/issues/136

# Changes
changed header ```Subscribed calendars``` level from h6 to h3

## Clarifications

*

# Screenshots & Video

<img width="963" height="294" alt="image" src="https://github.com/user-attachments/assets/7ccb2df2-6cb1-4d80-a49b-a4868621453d" />

# Executed Tests


* [x] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
